### PR TITLE
fix: 회원 권한 불러오기 및 회원 정보 변경 수정

### DIFF
--- a/src/main/java/com/phcworld/security/utils/SecurityUtil.java
+++ b/src/main/java/com/phcworld/security/utils/SecurityUtil.java
@@ -1,5 +1,6 @@
 package com.phcworld.security.utils;
 
+import com.phcworld.user.domain.Authority;
 import com.phcworld.user.dto.LoginUserRequestDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -24,15 +25,20 @@ public class SecurityUtil {
         return Long.valueOf(authentication.getName());
     }
 
-    public static String getAuthorities() {
+//    public static String getAuthorities() {
+    public static Authority getAuthorities() {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null || authentication.getName() == null) {
             throw new RuntimeException("Security Context 에 인증 정보가 없습니다.");
         }
-        return authentication.getAuthorities().stream()
+        String authorities = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
+        return Authority.valueOf(authorities);
+//        return authentication.getAuthorities().stream()
+//                .map(GrantedAuthority::getAuthority)
+//                .collect(Collectors.joining(","));
     }
 
     public static Authentication getAuthentication(LoginUserRequestDto requestDto,

--- a/src/test/java/com/phcworld/user/web/UserApiControllerTest.java
+++ b/src/test/java/com/phcworld/user/web/UserApiControllerTest.java
@@ -16,8 +16,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.io.File;
@@ -27,7 +25,6 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.Date;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -385,7 +382,7 @@ class UserApiControllerTest {
                         .with(csrf())
                         .header("Authorization", "Bearer " + accessToken))
                 .andDo(print())
-                .andExpect(status().isUnauthorized());
+                .andExpect(status().isOk());
     }
 
     @Test


### PR DESCRIPTION
- spring security context에서 권한을 가져올 때 String -> enum Authority로 변경해서 사용
- 프로필 이미지를 변경 후 정보 수정 요청을 할 경우 오류 수정